### PR TITLE
ci: GHA - Build & Test on PR & merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,19 +43,19 @@ jobs:
           find .
 
       - name: Prometheus check recording rules
-        uses: docker://prom/prometheus:latest
+        uses: docker://ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
         with:
           entrypoint: promtool
           args: check rules manifests/prometheus_rules.yaml
 
       - name: Prometheus check alerts
-        uses: docker://prom/prometheus:latest
+        uses: docker://ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
         with:
           entrypoint: promtool
           args: check rules manifests/prometheus_alerts.yaml
 
       - name: Prometheus test rules
-        uses: docker://prom/prometheus:latest
+        uses: docker://ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
         with:
           entrypoint: promtool
           args: test rules tests.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
+      options: --user root  # HACK GHA lack of repo mounting -> perm issues
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build/Render jsonnet
+        run: |
+          make build
+
+      - name: Archive manifests for testing and publishing
+        uses: actions/upload-artifact@v2
+        with:
+          name: manifests
+          path: |
+            manifests
+            tests.yaml
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download rendered manifests
+        uses: actions/download-artifact@v2
+        with:
+          name: manifests
+
+      - name: Show files
+        run: |
+          find .
+
+      - name: Prometheus check recording rules
+        uses: docker://prom/prometheus:latest
+        with:
+          entrypoint: promtool
+          args: check rules manifests/prometheus_rules.yaml
+
+      - name: Prometheus check alerts
+        uses: docker://prom/prometheus:latest
+        with:
+          entrypoint: promtool
+          args: check rules manifests/prometheus_alerts.yaml
+
+      - name: Prometheus test rules
+        uses: docker://prom/prometheus:latest
+        with:
+          entrypoint: promtool
+          args: test rules tests.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
         with:
           name: manifests
 
-      - name: Show files
-        run: |
-          find .
-
       - name: Prometheus check recording rules
         uses: docker://ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,40 +18,29 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build/Render jsonnet
-        run: |
-          make build
+        run:  make build
 
       - name: Archive manifests for testing and publishing
         uses: actions/upload-artifact@v2
         with:
           name: manifests
-          path: |
-            manifests
-            tests.yaml
+          path: manifests/
 
   test:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Download rendered manifests
         uses: actions/download-artifact@v2
         with:
           name: manifests
+          path: manifests/
 
-      - name: Prometheus check recording rules
+      - name: Test
         uses: docker://ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
         with:
-          entrypoint: promtool
-          args: check rules manifests/prometheus_rules.yaml
-
-      - name: Prometheus check alerts
-        uses: docker://ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
-        with:
-          entrypoint: promtool
-          args: check rules manifests/prometheus_alerts.yaml
-
-      - name: Prometheus test rules
-        uses: docker://ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
-        with:
-          entrypoint: promtool
-          args: test rules tests.yaml
+          entrypoint: make
+          args: test SKIP_DOCKER=true


### PR DESCRIPTION
Part of #4 

Part 1 of migrating CI from Gitlab - build and test on PR.

Using our OSS container image build/render jsonnet to json dashboards
and yaml Prometheus alerts & rules.

Then using upstream Prometheus image run `promtool` to test syntax and
alert condition tests.

Part 2 to follow separately - release.