### PR TITLE
feat(http): Standardise HTTP inbound & outbound panels

### DIFF
--- a/dashboards/clouddriver.jsonnet
+++ b/dashboards/clouddriver.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -774,10 +775,8 @@ grafana.dashboard.new(
   )
 )
 
-.addRow(
-  jvm
-)
+.addRow(hrm)
 
-.addRow(
-  kpm
-)
+.addRow(jvm)
+
+.addRow(kpm)

--- a/dashboards/deck.jsonnet
+++ b/dashboards/deck.jsonnet
@@ -78,6 +78,4 @@ grafana.dashboard.new(
   )
 )
 
-.addRow(
-  kpm
-)
+.addRow(kpm)

--- a/dashboards/echo.jsonnet
+++ b/dashboards/echo.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -77,52 +78,6 @@ grafana.dashboard.new(
       span=3,
     )
   )
-)
-
-.addRow(
-  grafana.row.new(
-    title='Additional Metrics',
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller 5xx Errors (echo, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance",status="5xx"}[$__rate_interval])) by (controller, method, statusCode)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocations by Method (echo, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocation Latency by Method (echo, $Instance)',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)\n/\nsum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
   .addPanel(
     grafana.graphPanel.new(
       title='Pipelines Triggered (echo, $Instance)',
@@ -138,10 +93,8 @@ grafana.dashboard.new(
   )
 )
 
-.addRow(
-  jvm
-)
+.addRow(hrm)
 
-.addRow(
-  kpm
-)
+.addRow(jvm)
+
+.addRow(kpm)

--- a/dashboards/fiat.jsonnet
+++ b/dashboards/fiat.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -79,56 +80,8 @@ grafana.dashboard.new(
   )
 )
 
-.addRow(
-  grafana.row.new(
-    title='Additional Metrics',
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='5xx Controller Invocations (fiat, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance",status="5xx"}[$__rate_interval])) by (controller, method, statusCode)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocations by Method (fiat, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocation Latency by Method (fiat, $Instance)',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)\n/\nsum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-)
+.addRow(hrm)
 
-.addRow(
-  jvm
-)
+.addRow(jvm)
 
-.addRow(
-  kpm
-)
+.addRow(kpm)

--- a/dashboards/front50.jsonnet
+++ b/dashboards/front50.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -124,19 +125,6 @@ grafana.dashboard.new(
   )
   .addPanel(
     grafana.graphPanel.new(
-      title='5xx Invocation Errors by Method (front50, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance", status="5xx"}[$__rate_interval])) by (controller, method, statusCode)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
       title='Cache Refreshes / Minute  (negative are scheduled) (front50, $Instance)',
       datasource='$datasource',
       span=3,
@@ -156,19 +144,6 @@ grafana.dashboard.new(
   )
   .addPanel(
     grafana.graphPanel.new(
-      title='Controller Invocation by Method (front50, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
       title='Item Cache Size (front50, $Instance)',
       datasource='$datasource',
       span=3,
@@ -177,20 +152,6 @@ grafana.dashboard.new(
       grafana.prometheus.target(
         'sum(storageServiceSupport_cacheSize{instance=~"$Instance"}) by (objectType)',
         legendFormat='{{objectType}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocation Latency by Method (front50, $Instance)',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)\n/ \nsum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
       )
     )
   )
@@ -282,10 +243,8 @@ grafana.dashboard.new(
   )
 )
 
-.addRow(
-  jvm
-)
+.addRow(hrm)
 
-.addRow(
-  kpm
-)
+.addRow(jvm)
+
+.addRow(kpm)

--- a/dashboards/gate.jsonnet
+++ b/dashboards/gate.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -135,58 +136,10 @@ grafana.dashboard.new(
       )
     )
   )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='5xx/429 Controller Invocations (gate, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance",status="5xx"}[$__rate_interval])) by (controller, method, statusCode)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance",statusCode="429"}[$__rate_interval])) by (controller, method, statusCode)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocations by Method (gate, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocation Latency by Method (gate, $Instance)',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)\n/\nsum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
 )
 
-.addRow(
-  jvm
-)
+.addRow(hrm)
 
-.addRow(
-  kpm
-)
+.addRow(jvm)
+
+.addRow(kpm)

--- a/dashboards/http-request-metrics.jsonnet
+++ b/dashboards/http-request-metrics.jsonnet
@@ -1,0 +1,113 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+
+grafana.row.new(
+  title='HTTP Metrics',
+)
+.addPanel(
+  grafana.graphPanel.new(
+    title='Inbound Request Rate by Method',
+    description='Inbound HTTP requests. \n\n`controller_invocations_total` is an enhanced version of Spring `http_server_requests_seconds_count` with additional labels.',
+    datasource='$datasource',
+    span=4,
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (controller, method) (rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval]))',
+      legendFormat='{{controller}}/{{method}}',
+    )
+  )
+)
+
+.addPanel(
+  grafana.graphPanel.new(
+    title='Inbound Request Latency by Method',
+    description='Inbound HTTP request latencies. \n\n`controller_invocations_total` is an enhanced version of Spring `http_server_requests_seconds_count` with additional labels.',
+    datasource='$datasource',
+    span=4,
+    format='dtdurations',
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (controller, method) (rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval]))\n / \n sum by (controller, method) (rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval]))',
+      legendFormat='{{controller}}/{{method}}',
+    )
+  )
+)
+
+.addPanel(
+  grafana.graphPanel.new(
+    title='Inbound Request Errors by Method',
+    description='Inbound HTTP request errors. \n\n`controller_invocations_total` is an enhanced version of Spring `http_server_requests_seconds_count` with additional labels.',
+    datasource='$datasource',
+    span=4,
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (statusCode, cause, controller, method) (rate(controller_invocations_total{job=~"$job", instance=~"$Instance", status="5xx"}[$__rate_interval]))',
+      legendFormat='{{statusCode}}/{{cause}}/{{controller}}/{{method}}',
+    )
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (statusCode, cause, controller, method) (rate(controller_invocations_total{job=~"$job", instance=~"$Instance", statusCode="429"}[$__rate_interval]))',
+      legendFormat='{{statusCode}}/{{cause}}/{{controller}}/{{method}}',
+    )
+  )
+)
+
+.addPanel(
+  grafana.graphPanel.new(
+    title='Outbound Request Rate',
+    description='Rate of outbound http requests to other Spinnaker services.',
+    datasource='$datasource',
+    span=4,
+    fill=0,
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (requestHost) (rate(okhttp_requests_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval]))',
+      legendFormat='{{requestHost}}',
+      interval='1m',
+    )
+  )
+)
+.addPanel(
+  grafana.graphPanel.new(
+    title='Outbound Request Latency',
+    description='Latency of outbound http requests to other Spinnaker services.',
+    datasource='$datasource',
+    span=4,
+    fill=0,
+    format='dtdurations',
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (requestHost) (rate(okhttp_requests_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval]))\n / \n sum by (requestHost) (rate(okhttp_requests_seconds_count{job="$job", instance=~"$Instance"}[$__rate_interval]))',
+      legendFormat='{{requestHost}}',
+      interval='1m',
+    )
+  )
+)
+.addPanel(
+  grafana.graphPanel.new(
+    title='Outbound Request Error Rate',
+    description='Rate of outbound http request errors when calling other Spinnaker services. \n\nCheck the logs looking for `retrofit error` or `<--- 500`',
+    datasource='$datasource',
+    span=4,
+    fill=0,
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (requestHost, statusCode) (rate(okhttp_requests_seconds_count{job=~"$job", instance=~"$Instance", status=~"(5xx|Unknown)"}[$__rate_interval]))',
+      legendFormat='{{statusCode}}/{{status}}/{{requestHost}}',
+      interval='1m',
+    )
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum by (requestHost, statusCode) (rate(okhttp_requests_seconds_count{job=~"$job", instance=~"$Instance", statusCode="429"}[$__rate_interval]))',
+      legendFormat='{{statusCode}}/{{requestHost}}',
+      interval='1m',
+    )
+  )
+)

--- a/dashboards/igor.jsonnet
+++ b/dashboards/igor.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -194,52 +195,10 @@ grafana.dashboard.new(
       )
     )
   )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='5xx Controller Invocations',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum by (controller, method, statusCode) (\n  rate(controller_invocations_total{job=~"$job",status="5xx", instance=~"$Instance"}[$__interval])\n)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocations by Method',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum by (controller, method) (\n  rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])\n)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocation Latency by Method',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum by (controller, method) (rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval]))\n/\nsum by (controller, method) (rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval]))',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
 )
 
-.addRow(
-  jvm
-)
+.addRow(hrm)
 
-.addRow(
-  kpm
-)
+.addRow(jvm)
+
+.addRow(kpm)

--- a/dashboards/kubernetes-pod-metrics.jsonnet
+++ b/dashboards/kubernetes-pod-metrics.jsonnet
@@ -1,4 +1,3 @@
-local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 
 grafana.row.new(

--- a/dashboards/orca.jsonnet
+++ b/dashboards/orca.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -259,87 +260,6 @@ grafana.dashboard.new(
   )
   .addPanel(
     grafana.graphPanel.new(
-      title='5xx Invocation Errors (orca, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance", status="5xx"}[$__rate_interval])) by (controller, method, status)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Stage Durations > 5m per Time-Bucket/Platform (orca, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(stage_invocations_duration_total{job=~"$job", instance=~"$Instance", bucket!="lt5m"}[$__rate_interval])) by (stageType, cloudProvider, bucket)',
-        legendFormat='{{bucket}}/{{cloudProvider}}/{{stageType}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Ok Http Calls by Status Code (orca, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(okhttp_requests_seconds_count{job=~"$job",instance=~"$Instance"}[$__rate_interval])) by (statusCode)',
-        legendFormat='{{statusCode}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Ok Http Calls Latency by Request Host (orca, $Instance)',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(okhttp_requests_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (requestHost)\n/\nsum(rate(okhttp_requests_seconds_count{job="$job", instance=~"$Instance"}[$__rate_interval])) by (requestHost)',
-        legendFormat='{{requestHost}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocations by Method (orca, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocation Latency by Method (orca, $Instance)',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)\n/\nsum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
       title='Active Stages per Type/Platform (orca, $Instance)',
       datasource='$datasource',
       span=3,
@@ -361,6 +281,19 @@ grafana.dashboard.new(
       grafana.prometheus.target(
         'sum(rate(stage_invocations_duration_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (cloudProvider, stageType)',
         legendFormat='{{stageType}}/{{cloudProvider}}',
+      )
+    )
+  )
+  .addPanel(
+    grafana.graphPanel.new(
+      title='Stage Durations > 5m per Time-Bucket/Platform (orca, $Instance)',
+      datasource='$datasource',
+      span=3,
+    )
+    .addTarget(
+      grafana.prometheus.target(
+        'sum(rate(stage_invocations_duration_total{job=~"$job", instance=~"$Instance", bucket!="lt5m"}[$__rate_interval])) by (stageType, cloudProvider, bucket)',
+        legendFormat='{{bucket}}/{{cloudProvider}}/{{stageType}}',
       )
     )
   )
@@ -508,10 +441,8 @@ grafana.dashboard.new(
   )
 )
 
-.addRow(
-  jvm
-)
+.addRow(hrm)
 
-.addRow(
-  kpm
-)
+.addRow(jvm)
+
+.addRow(kpm)

--- a/dashboards/rosco.jsonnet
+++ b/dashboards/rosco.jsonnet
@@ -1,3 +1,4 @@
+local hrm = import './http-request-metrics.jsonnet';
 local jvm = import './jvm-metrics.jsonnet';
 local kpm = import './kubernetes-pod-metrics.jsonnet';
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
@@ -161,56 +162,8 @@ grafana.dashboard.new(
   )
 )
 
-.addRow(
-  grafana.row.new(
-    title='Additional Metrics',
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller 5xx Errors (rosco, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job="$job",instance=~"$Instance",status="5xx"}[$__rate_interval])) by (controller, method, statusCode)',
-        legendFormat='{{statusCode}}/{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocations by Method (rosco, $Instance)',
-      datasource='$datasource',
-      span=3,
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_total{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-  .addPanel(
-    grafana.graphPanel.new(
-      title='Controller Invocation Latency by Method (rosco, $Instance)',
-      datasource='$datasource',
-      span=3,
-      format='dtdurations',
-    )
-    .addTarget(
-      grafana.prometheus.target(
-        'sum(rate(controller_invocations_seconds_sum{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)\n/\nsum(rate(controller_invocations_seconds_count{job=~"$job", instance=~"$Instance"}[$__rate_interval])) by (controller, method)',
-        legendFormat='{{controller}}/{{method}}',
-      )
-    )
-  )
-)
+.addRow(hrm)
 
-.addRow(
-  jvm
-)
+.addRow(jvm)
 
-.addRow(
-  kpm
-)
+.addRow(kpm)


### PR DESCRIPTION
closes #3 

`controller_invocations_total` is an enhanced version of Springs
`http_server_requests` metric with nicer label formatting and other
differences.

`okhttp_requests_seconds_{count|max|sum}` is for outbound requests.

As all Java services expose these metrics pull them out to a separate
file that we can import accordingly.